### PR TITLE
Fix preformance issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 /classes
+.idea
+*.iml

--- a/src/main/java/com/takipi/oss/benchmarks/jmh/loops/LoopBenchmarkMain.java
+++ b/src/main/java/com/takipi/oss/benchmarks/jmh/loops/LoopBenchmarkMain.java
@@ -116,8 +116,7 @@ public class LoopBenchmarkMain {
 	@Measurement(iterations = 5)
 	@Warmup(iterations = 5)
 	public int parallelStreamMaxInteger() {
-		Optional<Integer> max = integers.parallelStream().reduce(Integer::max);
-		return max.get();
+		return integers.parallelStream().mapToInt(Integer::intValue).reduce(Integer.MIN_VALUE, Integer::max);
 	}
 
 	@Benchmark

--- a/src/main/java/com/takipi/oss/benchmarks/jmh/loops/LoopBenchmarkMain.java
+++ b/src/main/java/com/takipi/oss/benchmarks/jmh/loops/LoopBenchmarkMain.java
@@ -137,6 +137,6 @@ public class LoopBenchmarkMain {
 	@Measurement(iterations = 5)
 	@Warmup(iterations = 5)
 	public int lambdaMaxInteger() {
-		return integers.stream().reduce(Integer.MIN_VALUE, (a, b) -> Integer.max(a, b));
+		return integers.stream().mapToInt(Integer::intValue).reduce(Integer.MIN_VALUE, (a, b) -> a >= b ? a : b);
 	}
 }

--- a/src/main/java/com/takipi/oss/benchmarks/jmh/loops/LoopBenchmarkMain.java
+++ b/src/main/java/com/takipi/oss/benchmarks/jmh/loops/LoopBenchmarkMain.java
@@ -127,8 +127,7 @@ public class LoopBenchmarkMain {
 	@Measurement(iterations = 5)
 	@Warmup(iterations = 5)
 	public int streamMaxInteger() {
-		Optional<Integer> max = integers.stream().reduce(Integer::max);
-		return max.get();
+		return integers.stream().mapToInt(Integer::intValue).reduce(Integer.MIN_VALUE, Integer::max);
 	}
 	
 	@Benchmark

--- a/src/main/java/com/takipi/oss/benchmarks/jmh/loops/LoopBenchmarkMain.java
+++ b/src/main/java/com/takipi/oss/benchmarks/jmh/loops/LoopBenchmarkMain.java
@@ -87,17 +87,12 @@ public class LoopBenchmarkMain {
 		final Wrapper wrapper = new Wrapper();
 		wrapper.inner = Integer.MIN_VALUE;
 		
-		integers.forEach(i -> helper(i, wrapper));
-		return wrapper.inner.intValue();
+		integers.forEach(i -> wrapper.inner = Integer.max(i, wrapper.inner));
+		return wrapper.inner;
 	}
 	
 	public static class Wrapper {
-		public Integer inner; 
-	}
-	
-	private int helper(int i, Wrapper wrapper) {
-		wrapper.inner = Math.max(i, wrapper.inner);
-		return wrapper.inner;
+		public int inner;
 	}
 	
 	@Benchmark


### PR DESCRIPTION
Before :
Benchmark                                                               Mode  Cnt  Score   Error    Units
LoopBenchmarkMain.forEachLambdaMaxInteger   avgt    10    0,711 ± 0,159  ms/op
LoopBenchmarkMain.forEachLoopMaxInteger        avgt    10    0,126 ± 0,003  ms/op
LoopBenchmarkMain.forMaxInteger                        avgt    10    0,233 ± 0,029  ms/op
LoopBenchmarkMain.iteratorMaxInteger                 avgt    10    0,127 ± 0,010  ms/op
LoopBenchmarkMain.lambdaMaxInteger                avgt    10    0,620 ± 0,063  ms/op
LoopBenchmarkMain.parallelStreamMaxInteger     avgt    10   0,490 ± 0,075  ms/op
LoopBenchmarkMain.streamMaxInteger                 avgt    10   0,673 ± 0,022  ms/op

After : 
Benchmark                                                               Mode  Cnt  Score   Error  Units
LoopBenchmarkMain.forEachLambdaMaxInteger   avgt   10  0,135 ± 0,031  ms/op
LoopBenchmarkMain.forEachLoopMaxInteger        avgt   10  0,127 ± 0,005  ms/op
LoopBenchmarkMain.forMaxInteger                        avgt   10  0,229 ± 0,010  ms/op
LoopBenchmarkMain.iteratorMaxInteger                 avgt   10  0,123 ± 0,002  ms/op
LoopBenchmarkMain.lambdaMaxInteger                avgt   10  0,104 ± 0,005  ms/op
LoopBenchmarkMain.parallelStreamMaxInteger     avgt   10  0,294 ± 0,038  ms/op
LoopBenchmarkMain.streamMaxInteger                 avgt   10  0,116 ± 0,005  ms/op

Thread something strange on parallelStreamMaxInteger, the result is not stable. But i think the operation is to fast to take advantage of parallel, maybe you can try with 10 000 000 of integers.

PS : I think your blog post needs to be updated :)

EDIT : 
By removing volatile, the result are better on forMaxInteger and parallelStreamMaxInteger :
Benchmark                                                             Mode  Cnt  Score   Error  Units
LoopBenchmarkMain.forEachLambdaMaxInteger  avgt   10  0,140 ± 0,032  ms/op
LoopBenchmarkMain.forEachLoopMaxInteger       avgt   10  0,125 ± 0,005  ms/op
LoopBenchmarkMain.forMaxInteger                       avgt   10  0,136 ± 0,065  ms/op
LoopBenchmarkMain.iteratorMaxInteger                avgt   10  0,140 ± 0,022  ms/op
LoopBenchmarkMain.lambdaMaxInteger               avgt   10  0,112 ± 0,002  ms/op
LoopBenchmarkMain.parallelStreamMaxInteger    avgt   10  0,083 ± 0,010  ms/op
LoopBenchmarkMain.streamMaxInteger                avgt   10  0,119 ± 0,010  ms/op 
