### PR TITLE
Add a benchmark that does a better job of exploring differences between iteration approaches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 /classes
+*.iml
+.idea

--- a/src/main/java/com/takipi/oss/benchmarks/jmh/loops/ByteArrayLoopBenchmark.java
+++ b/src/main/java/com/takipi/oss/benchmarks/jmh/loops/ByteArrayLoopBenchmark.java
@@ -35,7 +35,7 @@ public class ByteArrayLoopBenchmark {
     public void setup() {
         arrays = new ArrayList<>(size);
 
-        Random random = new Random();
+        Random random = new Random(123_456_789);
         for (int i = 0; i < size; i++) {
             byte[] arr = new byte[byteArrLength];
             random.nextBytes(arr);

--- a/src/main/java/com/takipi/oss/benchmarks/jmh/loops/ByteArrayLoopBenchmark.java
+++ b/src/main/java/com/takipi/oss/benchmarks/jmh/loops/ByteArrayLoopBenchmark.java
@@ -1,0 +1,107 @@
+package com.takipi.oss.benchmarks.jmh.loops;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Measurement(iterations = 5)
+@Warmup(iterations = 5)
+public class ByteArrayLoopBenchmark {
+    int size = 100_000;
+
+    int byteArrLength = 100;
+
+    List<byte[]> arrays;
+
+    @Setup
+    public void setup() {
+        arrays = new ArrayList<>(size);
+
+        Random random = new Random();
+        for (int i = 0; i < size; i++) {
+            byte[] arr = new byte[byteArrLength];
+            random.nextBytes(arr);
+            arrays.add(arr);
+        }
+    }
+
+    @Benchmark
+    public int iteratorMax() {
+        int max = Integer.MIN_VALUE;
+        for (Iterator<byte[]> it = arrays.iterator(); it.hasNext(); ) {
+            max = Integer.max(max, Arrays.hashCode(it.next()));
+        }
+        return max;
+    }
+
+    @Benchmark
+    public int forEachLoopMax() {
+        int max = Integer.MIN_VALUE;
+        for (byte[] n : arrays) {
+            max = Integer.max(max, Arrays.hashCode(n));
+        }
+        return max;
+    }
+
+    @Benchmark
+    public int forEachLambdaMax() {
+        MaxHolder maxHolder = new MaxHolder();
+        arrays.forEach(maxHolder::update);
+        return maxHolder.max;
+    }
+
+    @Benchmark
+    public int forMax() {
+        int max = Integer.MIN_VALUE;
+        for (int i = 0; i < arrays.size(); i++) {
+            max = Integer.max(max, Arrays.hashCode(arrays.get(i)));
+        }
+        return max;
+    }
+
+    @Benchmark
+    public int parallelStreamMax() {
+        return arrays.parallelStream().mapToInt(Arrays::hashCode).max().getAsInt();
+    }
+
+    @Benchmark
+    public int streamReduceMax() {
+        return arrays.stream().mapToInt(Arrays::hashCode).reduce(Integer::max).getAsInt();
+    }
+
+    @Benchmark
+    public int streamReduceMaxWithInitial() {
+        return arrays.stream().mapToInt(Arrays::hashCode).reduce(Integer.MIN_VALUE, Integer::max);
+    }
+
+    @Benchmark
+    public int streamMax() {
+        return arrays.stream().mapToInt(Arrays::hashCode).max().getAsInt();
+    }
+
+    public static class MaxHolder {
+        int max = Integer.MIN_VALUE;
+
+        void update(byte[] bytes) {
+            max = Math.max(Arrays.hashCode(bytes), max);
+        }
+    }
+}


### PR DESCRIPTION
The current benchmark (as you've seen in the comments on the [blog post](http://blog.takipi.com/benchmark-how-java-8-lambdas-and-streams-can-make-your-code-5-times-slower/)) is quite flawed: it's mostly a test of the compiler's ability to remove bounds checks and boxing.

This adds another benchmark that avoids these issues:
- It has fast but nontrivial work at for each array element (computing `hashCode()` of `byte[]`)
- Doesn't use volatile on fields
- Uses primitive streams where applicable

This is more representative of realworld workloads, I would claim. It also shows results much more inline with what makes sense, namely that they're all about the same except for parallel getting a good speedup.

```
ByteArrayLoopBenchmark.forEachLambdaMax            avgt   10  10.668 ± 0.161  ms/op
ByteArrayLoopBenchmark.forEachLoopMax              avgt   10  10.513 ± 0.008  ms/op
ByteArrayLoopBenchmark.forMax                      avgt   10  10.578 ± 0.073  ms/op
ByteArrayLoopBenchmark.iteratorMax                 avgt   10  10.507 ± 0.094  ms/op
ByteArrayLoopBenchmark.parallelStreamMax           avgt   10   1.919 ± 0.124  ms/op
ByteArrayLoopBenchmark.streamMax                   avgt   10  10.601 ± 0.153  ms/op
ByteArrayLoopBenchmark.streamReduceMax             avgt   10  10.695 ± 0.295  ms/op
ByteArrayLoopBenchmark.streamReduceMaxWithInitial  avgt   10  10.505 ± 0.149  ms/op
```

As further color on the volatile issue, your original benchmark produces this:

```
LoopBenchmarkMain.forEachLambdaMaxInteger          avgt   10   0.513 ± 0.034  ms/op
LoopBenchmarkMain.forEachLoopMaxInteger            avgt   10   0.123 ± 0.006  ms/op
LoopBenchmarkMain.forMaxInteger                    avgt   10   0.221 ± 0.043  ms/op
LoopBenchmarkMain.iteratorMaxInteger               avgt   10   0.104 ± 0.003  ms/op
LoopBenchmarkMain.lambdaMaxInteger                 avgt   10   0.468 ± 0.018  ms/op
LoopBenchmarkMain.parallelStreamMaxInteger         avgt   10   0.208 ± 0.028  ms/op
LoopBenchmarkMain.streamMaxInteger                 avgt   10   0.588 ± 0.020  ms/op
```

Just by removing the volatile modifier, forMaxInteger becomes the fastest, as is expected:

```
LoopBenchmarkMain.forEachLambdaMaxInteger   avgt   10  0.510 ± 0.018  ms/op
LoopBenchmarkMain.forEachLoopMaxInteger     avgt   10  0.123 ± 0.003  ms/op
LoopBenchmarkMain.forMaxInteger             avgt   10  0.099 ± 0.002  ms/op
LoopBenchmarkMain.iteratorMaxInteger        avgt   10  0.112 ± 0.015  ms/op
LoopBenchmarkMain.lambdaMaxInteger          avgt   10  0.466 ± 0.013  ms/op
LoopBenchmarkMain.parallelStreamMaxInteger  avgt   10  0.207 ± 0.014  ms/op
LoopBenchmarkMain.streamMaxInteger          avgt   10  0.579 ± 0.012  ms/op
```
