### PR TITLE
Parallel streams can be 8 times faster. 

### DIFF
--- a/.idea/libraries/Maven__org_openjdk_jmh_jmh_core_1_16.xml
+++ b/.idea/libraries/Maven__org_openjdk_jmh_jmh_core_1_16.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.openjdk.jmh:jmh-core:1.16">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-core/1.16/jmh-core-1.16.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-core/1.16/jmh-core-1.16-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-core/1.16/jmh-core-1.16-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_openjdk_jmh_jmh_generator_annprocess_1_16.xml
+++ b/.idea/libraries/Maven__org_openjdk_jmh_jmh_generator_annprocess_1_16.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.openjdk.jmh:jmh-generator-annprocess:1.16">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-generator-annprocess/1.16/jmh-generator-annprocess-1.16.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-generator-annprocess/1.16/jmh-generator-annprocess-1.16-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/openjdk/jmh/jmh-generator-annprocess/1.16/jmh-generator-annprocess-1.16-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
 # loops-jmh-playground
 
 Blog post about JMH
+
+# Run complete. Total time: 00:03:19
+Original from fixed
+```
+Benchmark                                   Mode  Cnt   Score   Error  Units
+LoopBenchmarkMain.forEachLambdaMaxInteger   avgt   10  21.741 ± 0.290  ms/op
+LoopBenchmarkMain.forEachLoopMaxInteger     avgt   10  15.762 ± 1.178  ms/op
+LoopBenchmarkMain.forMax2Integer            avgt   10  16.613 ± 1.302  ms/op
+LoopBenchmarkMain.forMaxInteger             avgt   10  16.471 ± 0.947  ms/op
+LoopBenchmarkMain.iteratorMaxInteger        avgt   10  15.761 ± 1.500  ms/op
+LoopBenchmarkMain.lambdaMaxInteger          avgt   10  15.717 ± 0.522  ms/op
+LoopBenchmarkMain.parallelStreamMaxInteger  avgt   10  10.439 ± 4.901  ms/op
+LoopBenchmarkMain.streamMaxInteger          avgt   10  15.860 ± 1.194  ms/op
+```
+
+Changes:
+Added IntStream(array)
+Added iterator.foreach
+removed the Wrapper.inner new
+increased the loop size to 100000
+Used Math.max instead of Integer.max
+``` 
+Benchmark                                         Mode  Cnt   Score   Error  Units
+LoopBenchmarkMain.collectionsMax2Integer          avgt   10  13.801 ± 0.868  ms/op
+LoopBenchmarkMain.collectionsMaxInteger           avgt   10  22.274 ± 1.209  ms/op
+LoopBenchmarkMain.forEachArrayLoopMaxInteger      avgt   10   8.994 ± 0.206  ms/op
+LoopBenchmarkMain.forEachLambdaMaxInteger         avgt   10  15.378 ± 0.716  ms/op
+LoopBenchmarkMain.forEachLoopMaxInteger           avgt   10  15.519 ± 1.327  ms/op
+LoopBenchmarkMain.forMax2Integer                  avgt   10  16.668 ± 0.723  ms/op
+LoopBenchmarkMain.forMaxInteger                   avgt   10  19.364 ± 2.275  ms/op
+LoopBenchmarkMain.iteratorMaxInteger              avgt   10  16.693 ± 1.330  ms/op
+LoopBenchmarkMain.parallelArrayStreamMax2Integer  avgt   10   2.301 ± 0.197  ms/op
+LoopBenchmarkMain.parallelArrayStreamMaxInteger   avgt   10   1.983 ± 0.402  ms/op
+LoopBenchmarkMain.parallelStreamMaxInteger        avgt   10   7.731 ± 0.284  ms/op
+LoopBenchmarkMain.streamArrayMax2Integer          avgt   10   9.311 ± 0.529  ms/op
+LoopBenchmarkMain.streamArrayMaxInteger           avgt   10   9.057 ± 0.325  ms/op
+LoopBenchmarkMain.streamMaxInteger                avgt   10  15.897 ± 1.193  ms/op
+```

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <maven>3.0</maven>
     </prerequisites>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.16</jmh.version>
+        <javac.target>1.8</javac.target>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
@@ -63,12 +70,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
         </dependency>
     </dependencies>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>1.11.2</jmh.version>
-        <javac.target>1.8</javac.target>
-        <uberjar.name>benchmarks</uberjar.name>
-    </properties>
 
     <build>
         <plugins>


### PR DESCRIPTION
Using:
java version "1.8.0_102"
Java(TM) SE Runtime Environment (build 1.8.0_102-b14)
Java HotSpot(TM) 64-Bit Server VM (build 25.102-b14, mixed mode)

Tests run on an 2015 15' maxbook pro ( quad core I7 at 2.5Ghz)

And:
- used Math.max instead of Integer.max
- added extra cases for stream.max() for timing
- added collections foreach case
- added int[] and IntStream.of() for comparisons.

## Conclusion
The average time for the parrallel stream on an IntStream.of([]) is approximately 8 times faster than the traditional for loop.
- Using Math.max is not necessarily faster.
- increasing the steam size causes better parrallel stream performances.
- using IntStream.of is a lot faster faster.
- using Stream.max is faster than aggregate.
- using the foreach on ArrayList collection is seriously slow.



